### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # kafka-connect-arangodb
-Kafka Connect connector for ArangoDB
+
+Kafka Connect ArangoDB Sink Connector
 
 ## Learn more
+
 - [ChangeLog](ChangeLog.md)
 - [Demo](./demo)
-- [Documentation](https://www.arangodb.com/docs/stable/drivers/)
+- [Documentation](https://www.arangodb.com/docs/stable/drivers/kafka-connector.html)


### PR DESCRIPTION
Should it be "Kafka Connect ArangoDB Sink Connector" or "Kafka Connect Sink Connector for ArangoDB"?
The repo description should also be adjusted accordingly.