### PR TITLE
[DE-1129] CI: test with Kafka 4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ jobs:
         default: 'single'
       kafka-version:
         type: 'string'
-        default: '4.1.1'
+        default: '4.2.0'
     environment:
       STARTER_MODE: <<parameters.topology>>
       DOCKER_IMAGE: <<parameters.docker-img>>
@@ -263,6 +263,7 @@ workflows:
               jdk:
                 - 'j17'
               kafka-version:
+                - '4.2.0'
                 - '4.1.1'
                 - '4.0.1'
 

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   kafka-1:
-    image: docker.io/apache/kafka-native:4.1.1
+    image: docker.io/apache/kafka-native:4.2.0
     ports:
       - '19092:19092'
     environment:
@@ -17,7 +17,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
 
   kafka-2:
-    image: docker.io/apache/kafka-native:4.1.1
+    image: docker.io/apache/kafka-native:4.2.0
     ports:
       - '29092:29092'
     environment:
@@ -32,7 +32,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
 
   kafka-3:
-    image: docker.io/apache/kafka-native:4.1.1
+    image: docker.io/apache/kafka-native:4.2.0
     ports:
       - '39092:39092'
     environment:
@@ -47,7 +47,7 @@ services:
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
 
   kafka-connect-1:
-    image: docker.io/apache/kafka:4.1.1
+    image: docker.io/apache/kafka:4.2.0
     depends_on:
       - kafka-1
       - kafka-2
@@ -60,7 +60,7 @@ services:
     command: /opt/kafka/bin/connect-distributed.sh /tmp/connect-distributed-1.properties
 
   kafka-connect-2:
-    image: docker.io/apache/kafka:4.1.1
+    image: docker.io/apache/kafka:4.2.0
     depends_on:
       - kafka-1
       - kafka-2

--- a/docker/start_kafka.sh
+++ b/docker/start_kafka.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-KAFKA_VERSION=${KAFKA_VERSION:=4.1.1}
+KAFKA_VERSION=${KAFKA_VERSION:=4.2.0}
 DOCKER_IMAGE=docker.io/apache/kafka-native:$KAFKA_VERSION
 docker pull $DOCKER_IMAGE
 

--- a/docker/start_kafka_connect.sh
+++ b/docker/start_kafka_connect.sh
@@ -3,7 +3,7 @@
 # exit when any command fails
 set -e
 
-KAFKA_VERSION=${KAFKA_VERSION:=4.1.1}
+KAFKA_VERSION=${KAFKA_VERSION:=4.2.0}
 DOCKER_IMAGE=docker.io/apache/kafka:$KAFKA_VERSION
 docker pull $DOCKER_IMAGE
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <kafka.version>4.1.1</kafka.version>
+        <kafka.version>4.2.0</kafka.version>
         <confluent.version>8.1.1</confluent.version>
         <arangodb.version>7.25.0</arangodb.version>
         <jackson.version>2.19.0</jackson.version>
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.27.6</version>
+            <version>3.27.7</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -240,7 +240,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.14.1</version>
+                <version>5.14.3</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -257,7 +257,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.14.1</version>
+                <version>3.15.0</version>
                 <configuration>
                     <compilerArgs>
                         <arg>-Xlint:unchecked</arg>
@@ -442,7 +442,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.9.0</version>
+                <version>0.10.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>
@@ -524,7 +524,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>versions-maven-plugin</artifactId>
-                <version>2.20.1</version>
+                <version>2.21.0</version>
                 <configuration>
                     <ruleSet>
                         <rules>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Primarily version bumps and CI/Docker configuration changes; risk is limited to potential incompatibilities with Kafka `4.2.0` affecting integration tests or local startup scripts.
> 
> **Overview**
> Updates the project’s default Kafka dependency/runtime version from `4.1.1` to `4.2.0` across CI and local/dev Docker tooling.
> 
> CircleCI’s distributed test workflow now includes a `4.2.0` matrix entry, and the Maven build bumps related test/build tool versions (`assertj`, `junit-bom`, `maven-compiler-plugin`, `central-publishing-maven-plugin`, `versions-maven-plugin`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbe9f18faadc146d1dd28917e8e3326b6a9eca40. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->